### PR TITLE
toolstash: compare compile, link, and asm tools

### DIFF
--- a/buildall
+++ b/buildall
@@ -31,7 +31,7 @@ if [ "$1" = "-work" ]; then
 fi
 
 cd $(go env GOROOT)/src
-go install cmd/{5,6,8,9}{g,l} cmd/old{5,6,8,9}a cmd/asm || exit 1
+go install cmd/compile cmd/link cmd/old{5,6,8,9}a cmd/asm || exit 1
 pattern="$1"
 if [ "$pattern" = "" ]; then
 	pattern=.
@@ -54,7 +54,7 @@ do
 		export GO386=387
 	fi
 	if $cmp; then
-		go build $work -a -toolexec 'toolstash -cmp' std
+		go build $work -a -toolexec 'toolstash -cmp' std cmd
 	else
 		go build $work -a std
 	fi


### PR DESCRIPTION
Give toolstash -cmp back its mojo.

I left in support for the old tool names for now, just in case.
